### PR TITLE
Move dump to the Openfire directory

### DIFF
--- a/src/changelog.html
+++ b/src/changelog.html
@@ -44,6 +44,11 @@
 Heapdump Plugin Changelog
 </h1>
 
+<p><b>1.0.1</b> -- (tbd)</p>
+<ul>
+    <li>[<a href='https://github.com/guusdk/openfire-heapdump-plugin/issues/1'>Issue #1</a>] - Plugin attempts to create heapdump in filesystem root</li>
+</ul>
+
 <p><b>1.0.0</b> -- January 7, 2021</p>
 <ul>
      <li>Initial release.</li>

--- a/src/main/java/org/igniterealtime/openfire/plugin/heapdump/HeapDumpPlugin.java
+++ b/src/main/java/org/igniterealtime/openfire/plugin/heapdump/HeapDumpPlugin.java
@@ -16,14 +16,18 @@
 package org.igniterealtime.openfire.plugin.heapdump;
 
 import com.sun.management.HotSpotDiagnosticMXBean;
+import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.container.Plugin;
 import org.jivesoftware.openfire.container.PluginManager;
+import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class HeapDumpPlugin implements Plugin
 {
@@ -57,11 +61,12 @@ public class HeapDumpPlugin implements Plugin
     {
         Log.info( "Generating heap dump in {}", outputFile );
         try {
+            String fullOutputPath = Paths.get(JiveGlobals.getHomeDirectory(), outputFile).toAbsolutePath().toString();
             ManagementFactory.newPlatformMXBeanProxy(
                     ManagementFactory.getPlatformMBeanServer(),
                     "com.sun.management:type=HotSpotDiagnostic",
                     HotSpotDiagnosticMXBean.class)
-                .dumpHeap(outputFile, live);
+                .dumpHeap(fullOutputPath, live);
             Log.info( "Heap dump generated in {}", outputFile );
         } catch (Exception e) {
             Log.info( "Heap dump generation failed.", e );


### PR DESCRIPTION
In docker, this attempts to place the file in the root of the filesystem, which fails without permissions. Move it to the Openfire root instead.